### PR TITLE
Fixed typos and add links to code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+All	participants agree to abide by the Code of Conduct available at https://github.com/openmainframeproject/tsc/blob/master/CODE_OF_CONDUCT.md.

--- a/governance.md
+++ b/governance.md
@@ -8,7 +8,7 @@ This project aims to be governed in a transparent, accessible way for the benefi
 
 The contributor role is the starting role for anyone participating in the project and wishing to contribute code.
 
-# Process for becoming a contributor
+### Process for becoming a contributor
 
 * Review the CONTRIBUTING.md guidelines to ensure your contribution is inline with the project's coding and styling guidelines.
 * Submit your code as a PR with the appropriate DCO signoff


### PR DESCRIPTION
Signed-off-by: John Mertic <jmertic@linuxfoundation.org>